### PR TITLE
new: custom edge attribute 

### DIFF
--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -191,6 +191,7 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         batch_size: int = 1000,
         keyify_nodes: bool = False,
         keyify_edges: bool = False,
+        edge_attr: str = "weight",
     ) -> ADBGraph:
         """Create an ArangoDB graph from a cuGraph graph, and a set of edge
         definitions.
@@ -216,6 +217,10 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
             Otherwise, ArangoDB _key values for edges will range from 1 to E,
             where E is the number of cugraph edges.
         :type keyify_edges: bool
+        :param edge_attr: If your cuGraph graph is weighted, you can specify
+            the edge attribute name used to represent your cuGraph edge weight values
+            once transferred into ArangoDB. Defaults to 'weight'.
+        :type edge_attr: str
         :return: The ArangoDB Graph API wrapper.
         :rtype: arango.graph.Graph
 
@@ -302,7 +307,7 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
             }
 
             if cug_graph.is_weighted():
-                adb_edge["weight"] = weight[0]
+                adb_edge[edge_attr] = weight[0]
 
             self.__insert_adb_docs(
                 col,


### PR DESCRIPTION
Given the `cugraph.from_cudf_edgelist()` [definition](https://docs.rapids.ai/api/cugraph/stable/api_docs/api/cugraph.Graph.from_cudf_edgelist.html#cugraph.Graph.from_cudf_edgelist), a cuGraph graph can store one edge attribute, which is normally designated for the edge weight.


### What's new
* Provide the option to the user to specify the edge attribute name when converting from ArangoDB to cuGraph. If unspecified, will default to checking if the attribute name `'weight'` exists. If it doesn't exist, set the edge weight to `0`.
* Provide the option to the user to specify the edge attribute name when converting from cuGraph to ArangoDB. If unspecified, will also default to `'weight'`.
