### PR TITLE
new: more adapter housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 <!-- [![Downloads](https://img.shields.io/conda/dn/arangodb/adbcug-adapter?style=for-the-badge&color=282661&label=Downloads)](https://anaconda.org/arangodb/adbcug-adapter/badges/downloads.svg
 ) -->
 
-<a href="https://www.arangodb.com/" rel="arangodb.com">![](./examples/assets/logos/ArangoDB_logo.png)</a>
-<a href="https://github.com/rapidsai/cugraph" rel="github.com/rapidsai/cugraph"><img src="./examples/assets/logos/rapids_logo.png" width=30% height=30%></a>
+<a href="https://www.arangodb.com/" rel="arangodb.com">![](https://raw.githubusercontent.com/arangoml/cugraph-adapter/master/examples/assets/logos/ArangoDB_logo.png)</a>
+<a href="https://github.com/rapidsai/cugraph" rel="github.com/rapidsai/cugraph"><img src="https://raw.githubusercontent.com/arangoml/cugraph-adapter/master/examples/assets/logos/rapids_logo.png" width=30% height=30%></a>
 
 The ArangoDB-cuGraph Adapter exports Graphs from ArangoDB, the multi-model database for graph & beyond, into RAPIDS cuGraph, a library of collective GPU-accelerated graph algorithms, and vice-versa.
 

--- a/adbcug_adapter/abc.py
+++ b/adbcug_adapter/abc.py
@@ -65,6 +65,7 @@ class Abstract_ADBCUG_Controller(ABC):
         from_cug_node: Json,
         to_cug_node: Json,
         adb_e_cols: List[str],
+        weight: Optional[Any] = None,
     ) -> str:
         raise NotImplementedError  # pragma: no cover
 

--- a/adbcug_adapter/abc.py
+++ b/adbcug_adapter/abc.py
@@ -52,6 +52,9 @@ class Abstract_ADBCUG_Adapter(ABC):
     def __fetch_adb_docs(self) -> None:
         raise NotImplementedError  # pragma: no cover
 
+    def __insert_adb_docs(self) -> None:
+        raise NotImplementedError  # pragma: no cover
+
 
 class Abstract_ADBCUG_Controller(ABC):
     def _prepare_arangodb_vertex(self, adb_vertex: Json, col: str) -> None:

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -330,7 +330,9 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
             col = (
                 adb_e_cols[0]
                 if has_one_ecol
-                else self.__cntrl._identify_cugraph_edge(from_n, to_n, adb_e_cols)
+                else self.__cntrl._identify_cugraph_edge(
+                    from_n, to_n, adb_e_cols, weight[0] if weight else None
+                )
             )
 
             if col not in adb_e_cols:

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -113,12 +113,12 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
 
         adb_v: Json
         for v_col, _ in metagraph["vertexCollections"].items():
-            total = self.__db.collection(v_col).count()
-            logger.debug(f"Preparing {total} '{v_col}' vertices")
+            logger.debug(f"Preparing '{v_col}' vertices")
 
+            cursor = self.__fetch_adb_docs(v_col, query_options)
             for adb_v in tqdm(
-                self.__fetch_adb_docs(v_col, query_options),
-                total=total,
+                cursor,
+                total=cursor.count(),
                 desc=v_col,
                 colour="CYAN",
                 disable=logger.level > logging.INFO,
@@ -131,12 +131,12 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
 
         adb_e: Json
         for e_col, _ in metagraph["edgeCollections"].items():
-            total = self.__db.collection(e_col).count()
-            logger.debug(f"Preparing {total} '{e_col}' edges")
+            logger.debug(f"Preparing '{e_col}' edges")
 
+            cursor = self.__fetch_adb_docs(e_col, query_options)
             for adb_e in tqdm(
-                self.__fetch_adb_docs(e_col, query_options),
-                total=total,
+                cursor,
+                total=cursor.count(),
                 desc=e_col,
                 colour="GREEN",
                 disable=logger.level > logging.INFO,
@@ -405,12 +405,12 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         :return: Result cursor.
         :rtype: arango.cursor.Cursor
         """
-        aql = f"""
-            FOR doc IN {col}
+        aql = """
+            FOR doc IN @@col
                 RETURN doc
         """
 
-        return self.__db.aql.execute(aql, **query_options)
+        return self.__db.aql.execute(aql, count=True, bind_vars={'@col': col}, **query_options)
 
     def __insert_adb_docs(
         self, adb_documents: DefaultDict[str, List[Json]], import_options: Any

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -114,9 +114,9 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         for col, _ in metagraph["vertexCollections"].items():
             logger.debug(f"Preparing '{col}' vertices")
             for i, adb_v in enumerate(self.__fetch_adb_docs(col, query_options), 1):
-                logger.debug(f'V{i}: {adb_v["_id"]}')
-
                 adb_id: str = adb_v["_id"]
+                logger.debug(f"V{i}: {adb_id}")
+
                 self.__cntrl._prepare_arangodb_vertex(adb_v, col)
                 cug_id: str = adb_v["_id"]
 

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -57,11 +57,11 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
 
     @property
     def db(self) -> Database:
-        return self.__db
+        return self.__db  # pragma: no cover
 
     @property
     def cntrl(self) -> ADBCUG_Controller:
-        return self.__cntrl
+        return self.__cntrl  # pragma: no cover
 
     def set_logging(self, level: Union[int, str]) -> None:
         logger.setLevel(level)

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -410,7 +410,9 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
                 RETURN doc
         """
 
-        return self.__db.aql.execute(aql, count=True, bind_vars={'@col': col}, **query_options)
+        return self.__db.aql.execute(
+            aql, count=True, bind_vars={"@col": col}, **query_options
+        )
 
     def __insert_adb_docs(
         self, adb_documents: DefaultDict[str, List[Json]], import_options: Any

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -266,8 +266,10 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         else:
             adb_graph = self.__db.create_graph(name, edge_definitions)
 
-        adb_v_cols = adb_graph.vertex_collections()
-        adb_e_cols = [e_d["edge_collection"] for e_d in adb_graph.edge_definitions()]
+        adb_v_cols: List[str] = adb_graph.vertex_collections()
+        adb_e_cols: List[str] = [
+            e_d["edge_collection"] for e_d in adb_graph.edge_definitions()
+        ]
 
         has_one_vcol = len(adb_v_cols) == 1
         has_one_ecol = len(adb_e_cols) == 1
@@ -285,6 +287,11 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
                 if has_one_vcol
                 else self.__cntrl._identify_cugraph_node(cug_id, adb_v_cols)
             )
+
+            if col not in adb_v_cols:
+                msg = f"'{cug_id}' identified as '{col}', which is not in {adb_v_cols}"
+                raise ValueError(msg)
+
             key = (
                 self.__cntrl._keyify_cugraph_node(cug_id, col)
                 if keyify_nodes
@@ -315,6 +322,12 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
                 if has_one_ecol
                 else self.__cntrl._identify_cugraph_edge(from_n, to_n, adb_e_cols)
             )
+
+            if col not in adb_e_cols:
+                cug_edge = f"'({from_node_id}, {to_node_id})'"
+                msg = f"{cug_edge} identified as '{col}', which is not in {adb_e_cols}"
+                raise ValueError(msg)
+
             key = (
                 self.__cntrl._keyify_cugraph_edge(from_n, to_n, col)
                 if keyify_edges

--- a/adbcug_adapter/adapter.py
+++ b/adbcug_adapter/adapter.py
@@ -113,19 +113,19 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         for col, _ in metagraph["vertexCollections"].items():
             logger.debug(f"Preparing '{col}' vertices")
             for i, adb_v in enumerate(self.__fetch_adb_docs(col, query_options), 1):
+                logger.debug(f'V{i}: {adb_v["_id"]}')
+
                 adb_id: str = adb_v["_id"]
-                logger.debug(f"Vertex {i}: {adb_id}")
-
                 self.__cntrl._prepare_arangodb_vertex(adb_v, col)
-
                 cug_id: str = adb_v["_id"]
+
                 adb_map[adb_id] = {"cug_id": cug_id, "collection": col}
 
         adb_e: Json
         for col, _ in metagraph["edgeCollections"].items():
             logger.debug(f"Preparing '{col}' edges")
             for i, adb_e in enumerate(self.__fetch_adb_docs(col, query_options), 1):
-                logger.debug(f"Edge {i}: {adb_e['_id']}")
+                logger.debug(f"E{i}: {adb_e['_id']}")
 
                 from_node_id: CUGId = adb_map[adb_e["_from"]]["cug_id"]
                 to_node_id: CUGId = adb_map[adb_e["_to"]]["cug_id"]
@@ -287,7 +287,7 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         cug_nodes = cug_graph.nodes().values_host
         logger.debug(f"Preparing {len(cug_nodes)} cugraph nodes")
         for i, cug_id in enumerate(cug_nodes, 1):
-            logger.debug(f"Node {i}: {cug_id}")
+            logger.debug(f"N{i}: {cug_id}")
 
             col = (
                 adb_v_cols[0]
@@ -321,8 +321,8 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
         for i, (from_node_id, to_node_id, *weight) in enumerate(
             cug_graph.view_edge_list().values_host, 1
         ):
-            cug_edge = f"'({from_node_id}, {to_node_id})'"
-            logger.debug(f"Edge {i}: {cug_edge}")
+            edge_str = f"({from_node_id}, {to_node_id})"
+            logger.debug(f"E{i}: {edge_str}")
 
             from_n = cug_map[from_node_id]
             to_n = cug_map[to_node_id]
@@ -334,7 +334,7 @@ class ADBCUG_Adapter(Abstract_ADBCUG_Adapter):
             )
 
             if col not in adb_e_cols:
-                msg = f"{cug_edge} identified as '{col}', which is not in {adb_e_cols}"
+                msg = f"{edge_str} identified as '{col}', which is not in {adb_e_cols}"
                 raise ValueError(msg)
 
             key = (

--- a/adbcug_adapter/controller.py
+++ b/adbcug_adapter/controller.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from typing import List
+from typing import Any, List, Optional
 
 from .abc import Abstract_ADBCUG_Controller
 from .typings import CUGId, Json
@@ -57,6 +57,7 @@ class ADBCUG_Controller(Abstract_ADBCUG_Controller):
         from_cug_node: Json,
         to_cug_node: Json,
         adb_e_cols: List[str],
+        weight: Optional[Any] = None,
     ) -> str:
         """Given a pair of connected cuGraph nodes, and a list of ArangoDB
         edge collections defined, identify which ArangoDB edge collection it
@@ -76,6 +77,8 @@ class ADBCUG_Controller(Abstract_ADBCUG_Controller):
             by the **edge_definitions** parameter of
             ADBCUG_Adapter.cugraph_to_arangodb()
         :type adb_e_cols: List[str]
+        :param weight: The edge attribute (i.e weight) value of the edge.
+        :type weight: any
         :return: The ArangoDB collection name
         :rtype: str
         """

--- a/adbcug_adapter/controller.py
+++ b/adbcug_adapter/controller.py
@@ -30,7 +30,7 @@ class ADBCUG_Controller(Abstract_ADBCUG_Controller):
         :param col: The ArangoDB collection the vertex belongs to.
         :type col: str
         """
-        return
+        pass
 
     def _identify_cugraph_node(self, cug_node_id: CUGId, adb_v_cols: List[str]) -> str:
         """Given a cuGraph node, and a list of ArangoDB vertex collections defined,

--- a/adbcug_adapter/controller.py
+++ b/adbcug_adapter/controller.py
@@ -37,7 +37,7 @@ class ADBCUG_Controller(Abstract_ADBCUG_Controller):
         identify which ArangoDB vertex collection it should belong to.
 
         NOTE: You must override this function if len(**adb_v_cols**) > 1
-        OR **cug_node_id* does NOT comply to ArangoDB standards
+        AND **cug_node_id* does NOT comply to ArangoDB standards
         (i.e "{collection}/{key}").
 
         :param cug_node_id: The cuGraph ID of the vertex.
@@ -100,7 +100,7 @@ class ADBCUG_Controller(Abstract_ADBCUG_Controller):
         # Otherwise, user must override this function if custom ArangoDB _key
         # values are required for nodes
         adb_vertex_id: str = str(cug_node_id)
-        return adb_vertex_id.split("/")[1]
+        return self._string_to_arangodb_key_helper(adb_vertex_id.split("/")[1])
 
     def _keyify_cugraph_edge(
         self,

--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -10,3 +10,4 @@ dependencies:
 - python>=3.7,<3.10
 - pip:
   - python-arango>=7.4.1
+  - conda>=4.64.0

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - cudatoolkit>=11.2
     - cugraph>=21.12
     - python-arango>=7.4.1
+    - tqdm>=4.64.0
     - python>=3.7,<3.10
 
 about:

--- a/examples/ArangoDB_cuGraph_Adapter.ipynb
+++ b/examples/ArangoDB_cuGraph_Adapter.ipynb
@@ -285,7 +285,7 @@
     "import json\n",
     "import logging\n",
     "import io, requests\n",
-    "from typing import List"
+    "from typing import List, Optional, Any"
    ]
   },
   {
@@ -1012,6 +1012,7 @@
     "      from_cug_node: Json,\n",
     "      to_cug_node: Json,\n",
     "      adb_e_cols: List[str],\n",
+    "      weight: Optional[Any] = None,\n",
     "  ) -> str:\n",
     "    \"\"\"Given a pair of connected cuGraph nodes, and a list of ArangoDB\n",
     "    edge collections defined, identify which ArangoDB edge collection it\n",
@@ -1031,6 +1032,8 @@
     "        by the **edge_definitions** parameter of\n",
     "        ADBCUG_Adapter.cugraph_to_arangodb()\n",
     "    :type adb_e_cols: List[str]\n",
+    "    :param weight: The edge attribute (i.e weight) value of the edge.\n",
+    "    :type weight: any\n",
     "    :return: The ArangoDB collection name\n",
     "    :rtype: str\n",
     "    \"\"\"\n",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     license="Apache Software License",
     install_requires=[
         "python-arango>=7.4.1",
-        "tqdm>=4.64.0"
+        "tqdm>=4.64.0",
         "setuptools>=42",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     license="Apache Software License",
     install_requires=[
         "python-arango>=7.4.1",
+        "tqdm>=4.64.0"
         "setuptools>=42",
     ],
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Optional
 
 from arango import ArangoClient
 from arango.database import StandardDatabase
@@ -48,9 +48,10 @@ def pytest_configure(config: Any) -> None:
         con["dbName"], con["username"], con["password"], verify=True
     )
 
-    global adbcug_adapter, custom_adbcug_adapter
+    global adbcug_adapter, bipartite_adbcug_adapter, likes_adbcug_adapter
     adbcug_adapter = ADBCUG_Adapter(db, logging_lvl=logging.DEBUG)
-    custom_adbcug_adapter = ADBCUG_Adapter(db, Custom_ADBCUG_Controller())
+    bipartite_adbcug_adapter = ADBCUG_Adapter(db, Bipartite_ADBCUG_Controller())
+    likes_adbcug_adapter = ADBCUG_Adapter(db, Likes_ADBCUG_Controller())
 
     arango_restore(con, "examples/data/fraud_dump")
     arango_restore(con, "examples/data/imdb_dump")
@@ -123,6 +124,46 @@ def get_bipartite_graph() -> CUGGraph:
     return cug_graph
 
 
-class Custom_ADBCUG_Controller(ADBCUG_Controller):
+class Bipartite_ADBCUG_Controller(ADBCUG_Controller):
     def _keyify_cugraph_node(self, cug_node_id: CUGId, col: str) -> str:
         return self._string_to_arangodb_key_helper(str(cug_node_id).split("/")[1])
+
+
+def get_drivers_graph() -> CUGraph:
+    edges = DataFrame(
+        [("P-John", "C-BMW"), ("P-Mark", "C-Audi")],
+        columns=["src", "dst"],
+    )
+
+    cug_graph = CUGGraph()
+    cug_graph.from_cudf_edgelist(edges, source="src", destination="dst", renumber=False)
+    return cug_graph
+
+
+def get_likes_graph() -> CUGraph:
+    edges = DataFrame(
+        [("P-John", "P-Emily", True), ("P-Emily", "P-John", False)],
+        columns=["src", "dst", "likes"],
+    )
+
+    cug_graph = CUGGraph()
+    cug_graph.from_cudf_edgelist(
+        edges, source="src", destination="dst", edge_attr="likes", renumber=False
+    )
+    return cug_graph
+
+
+class Likes_ADBCUG_Controller(ADBCUG_Controller):
+    def _identify_cugraph_edge(
+        self,
+        from_cug_node: Json,
+        to_cug_node: Json,
+        adb_e_cols: List[str],
+        weight: Optional[Any] = None,
+    ) -> str:
+        if weight is True:
+            return "likes"
+        elif weight is False:
+            return "dislikes"
+        else:
+            raise ValueError(f"Unrecognized 'weight' value: {weight}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,26 +54,36 @@ def pytest_configure(config: Any) -> None:
     bipartite_adbcug_adapter = ADBCUG_Adapter(db, Bipartite_ADBCUG_Controller())
     likes_adbcug_adapter = ADBCUG_Adapter(db, Likes_ADBCUG_Controller())
 
-    arango_restore(con, "examples/data/fraud_dump")
-    arango_restore(con, "examples/data/imdb_dump")
+    if db.has_graph("fraud-detection") is False:
+        arango_restore(con, "examples/data/fraud_dump")
+        db.create_graph(
+            "fraud-detection",
+            edge_definitions=[
+                {
+                    "edge_collection": "accountHolder",
+                    "from_vertex_collections": ["customer"],
+                    "to_vertex_collections": ["account"],
+                },
+                {
+                    "edge_collection": "transaction",
+                    "from_vertex_collections": ["account"],
+                    "to_vertex_collections": ["account"],
+                },
+            ],
+        )
 
-    # Create Fraud Detection Graph
-    adbcug_adapter.db.delete_graph("fraud-detection", ignore_missing=True)
-    adbcug_adapter.db.create_graph(
-        "fraud-detection",
-        edge_definitions=[
-            {
-                "edge_collection": "accountHolder",
-                "from_vertex_collections": ["customer"],
-                "to_vertex_collections": ["account"],
-            },
-            {
-                "edge_collection": "transaction",
-                "from_vertex_collections": ["account"],
-                "to_vertex_collections": ["account"],
-            },
-        ],
-    )
+    if db.has_graph("imdb") is False:
+        arango_restore(con, "examples/data/imdb_dump")
+        db.create_graph(
+            "imdb",
+            edge_definitions=[
+                {
+                    "edge_collection": "Ratings",
+                    "from_vertex_collections": ["Users"],
+                    "to_vertex_collections": ["Movies"],
+                },
+            ],
+        )
 
 
 def arango_restore(con: Json, path_to_data: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ PROJECT_DIR = Path(__file__).parent.parent
 
 db: StandardDatabase
 adbcug_adapter: ADBCUG_Adapter
-custom_adbcug_adapter: ADBCUG_Adapter
+bipartite_adbcug_adapter: ADBCUG_Adapter
+likes_adbcug_adapter: ADBCUG_Adapter
 
 
 def pytest_addoption(parser: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,6 @@ class Likes_ADBCUG_Controller(ADBCUG_Controller):
         if weight is True:
             return "likes"
         elif weight is False:
-            return "dislikes"
+            return "dislikes_intentional_typo_here"
         else:
             raise ValueError(f"Unrecognized 'weight' value: {weight}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,7 @@ class Bipartite_ADBCUG_Controller(ADBCUG_Controller):
         return self._string_to_arangodb_key_helper(str(cug_node_id).split("/")[1])
 
 
-def get_drivers_graph() -> CUGraph:
+def get_drivers_graph() -> CUGGraph:
     edges = DataFrame(
         [("P-John", "C-BMW"), ("P-Mark", "C-Audi")],
         columns=["src", "dst"],
@@ -140,7 +140,7 @@ def get_drivers_graph() -> CUGraph:
     return cug_graph
 
 
-def get_likes_graph() -> CUGraph:
+def get_likes_graph() -> CUGGraph:
     edges = DataFrame(
         [("P-John", "P-Emily", True), ("P-Emily", "P-John", False)],
         columns=["src", "dst", "likes"],

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -10,10 +10,13 @@ from adbcug_adapter.typings import ADBMetagraph, Json
 
 from .conftest import (
     adbcug_adapter,
-    custom_adbcug_adapter,
+    bipartite_adbcug_adapter,
     db,
     get_bipartite_graph,
     get_divisibility_graph,
+    get_drivers_graph,
+    get_likes_graph,
+    likes_adbcug_adapter,
 )
 
 
@@ -170,7 +173,7 @@ def test_adb_graph_to_cug(
             {"overwrite": True},
         ),
         (
-            custom_adbcug_adapter,
+            bipartite_adbcug_adapter,
             "SampleBipartiteGraph",
             get_bipartite_graph(),
             [
@@ -217,6 +220,37 @@ def test_cug_to_adb(
         keyify_edges,
         edge_attr,
     )
+
+
+def test_cug_to_adb_invalid_collections() -> None:
+    cug_g_1 = get_drivers_graph()
+    e_d_1 = [
+        {
+            "edge_collection": "drives",
+            "from_vertex_collections": ["Person"],
+            "to_vertex_collections": ["Car"],
+        }
+    ]
+    # Raise ValueError on invalid vertex collection identification
+    with pytest.raises(ValueError):
+        adbcug_adapter.cugraph_to_arangodb("Drivers", cug_g_1, e_d_1)
+
+    cug_g_2 = get_likes_graph()
+    e_d_2 = [
+        {
+            "edge_collection": "likes",
+            "from_vertex_collections": ["Person"],
+            "to_vertex_collections": ["Person"],
+        },
+        {
+            "edge_collection": "dislikes",
+            "from_vertex_collections": ["Person"],
+            "to_vertex_collections": ["Person"],
+        },
+    ]
+    # Raise ValueError on invalid edge collection identification
+    with pytest.raises(ValueError):
+        likes_adbcug_adapter.cugraph_to_arangodb("Feelings", cug_g_2, e_d_2)
 
 
 def assert_arangodb_data(

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -170,7 +170,7 @@ def test_adb_graph_to_cug(
             False,
             False,
             "quotient",
-            {"on_duplicate": "replace"},
+            {"overwrite": True},
         ),
         (
             bipartite_adbcug_adapter,
@@ -187,7 +187,7 @@ def test_adb_graph_to_cug(
             False,
             True,
             "",
-            {"on_duplicate": "replace"},
+            {"overwrite": True},
         ),
     ],
 )

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -233,7 +233,9 @@ def test_cug_to_adb_invalid_collections() -> None:
     ]
     # Raise ValueError on invalid vertex collection identification
     with pytest.raises(ValueError):
-        adbcug_adapter.cugraph_to_arangodb("Drivers", cug_g_1, e_d_1)
+        adbcug_adapter.cugraph_to_arangodb(
+            "Drivers", cug_g_1, e_d_1, on_duplicate="replace"
+        )
 
     cug_g_2 = get_likes_graph()
     e_d_2 = [
@@ -250,7 +252,9 @@ def test_cug_to_adb_invalid_collections() -> None:
     ]
     # Raise ValueError on invalid edge collection identification
     with pytest.raises(ValueError):
-        likes_adbcug_adapter.cugraph_to_arangodb("Feelings", cug_g_2, e_d_2)
+        likes_adbcug_adapter.cugraph_to_arangodb(
+            "Feelings", cug_g_2, e_d_2, on_duplicate="replace"
+        )
 
 
 def assert_arangodb_data(

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -170,7 +170,7 @@ def test_adb_graph_to_cug(
             False,
             False,
             "quotient",
-            {"overwrite": True},
+            {"on_duplicate": "replace"},
         ),
         (
             bipartite_adbcug_adapter,
@@ -187,7 +187,7 @@ def test_adb_graph_to_cug(
             False,
             True,
             "",
-            {"overwrite": True},
+            {"on_duplicate": "replace"},
         ),
     ],
 )


### PR DESCRIPTION
Note: The scope of this PR has widened, but the branch name has not been updated

### What's new
* raises a `ValueError` if the result of `identify_cugraph_node` or `identify_cugraph_edge` is not valid
* adds node/edge level logging via a `tqdm` progress meter
* docstring updates
* new `test_cug_to_adb_invalid_collections` test case
* introduces the optional `weight` parameter to `identify_cugraph_edge`
* new `__insert_adb_docs` method